### PR TITLE
Fix/magicquery crashes

### DIFF
--- a/PacketPeep/Widgets/MagicQuery.cs
+++ b/PacketPeep/Widgets/MagicQuery.cs
@@ -110,7 +110,7 @@ public class MagicQuery
         int numResults = results.Sum(x => x.Rows.Count);
         var combinedResults = new QueryResult
         {
-            Headers = results[0].Headers,
+            Headers = numResults > 0 ? results[0].Headers : new(string, Type)[] {("No Results", typeof(string))},
             Rows    = new(numResults)
         };
 

--- a/PacketPeep/Widgets/MagicQuery.cs
+++ b/PacketPeep/Widgets/MagicQuery.cs
@@ -102,7 +102,22 @@ public class MagicQuery
             chunkTasks.Add(task);
         }
 
-        Task.WhenAll(chunkTasks).Wait();
+        try {
+            Task.WhenAll(chunkTasks).Wait();
+        }
+        catch (AggregateException ae) {
+            sw.Stop();
+
+            var exceptions = ae.Flatten().InnerExceptions;
+            var ex = exceptions[0];
+            PacketPeepTool.Log.AddLogWarn(LogCategories.QueryEngine, $"{exceptions.Count} errors occured while executing the query.");
+            PacketPeepTool.Log.AddLogError(LogCategories.QueryEngine, $"{ex.GetType()}: {ex.Message}");
+            return new QueryResult
+            {
+                Headers = new(string, Type)[] {($"Error: {ex.Message}", typeof(string))},
+                Rows    = new(0)
+            };
+        }
 
         // Combine all the results
         var combineSw  = Stopwatch.StartNew();


### PR DESCRIPTION
These changes fix two cases where magic query caused exceptions that crashed peep.

Previously, if a valid query returned no results, it would still try to get the headers from that result and thus crash. Now it will instead print a heading that says there were no results.

Previously, anything like a syntax error or an invalid property name would cause a crash from various exceptions thrown from the compilation or execution. Now, if any exception occurs on any of the threads it will just print the first exception in a heading and log more details. I limited it to the first exception because in all of the common scenarios we'll have the same exception on all threads.