### PR TITLE
Fix/jack bugs

### DIFF
--- a/PacketPeep/Tabs/MainTab.cs
+++ b/PacketPeep/Tabs/MainTab.cs
@@ -98,7 +98,7 @@ namespace PacketPeep.Widgets
 
             var msg            = PacketExp.GetMsg(idx);
             var parsedMessages = PacketExp.GetActiveSession().ParsedMessages;
-            var msgObj         = parsedMessages != null && parsedMessages.Count >= idx ? parsedMessages[idx] : null;
+            var msgObj         = parsedMessages != null && parsedMessages.Count != 0 && parsedMessages.Count >= idx ? parsedMessages[idx] : null;
             var msgInspector   = new MessageInspector(PacketExp.ActiveFilter.SessionName, idx, msg, msgObj);
             msgInspector.OnClose = CloseMessageInspector;
             MsgInspectors.Add(msgInspector);

--- a/PacketPeep/Utils.cs
+++ b/PacketPeep/Utils.cs
@@ -111,9 +111,12 @@ namespace PacketPeep
                 header.EntityId     = BitConverter.ToUInt64(msg.Data[..8]) >> 8;
                 header.Length       = 9;
             }
-            else {
+            else if (isGameMsg) {
                 header.MessageId = msg.Data[0];
                 header.Length    = 1;
+            }
+            else {
+                header.Length = 0;
             }
 
             return header;


### PR DESCRIPTION
These changes fix two issues with the matrix handshake messages.

One where peep would crash if the first message of the session was being opened, which was related to the index being 0 and the message not being parsed.

Additionally, the hex view of these messages was cutting of the first byte because of logic related to hiding the channel header bytes of control and matrix messages. I adjusted this so that no bytes are hidden on non-game messages, though we could also consider hiding the first four bytes of these messages since we already present the type ourselves.