### PR TITLE
Fix/messagefinder bugs

### DIFF
--- a/PacketPeep/Widgets/PacketExplorer.cs
+++ b/PacketPeep/Widgets/PacketExplorer.cs
@@ -167,7 +167,7 @@ namespace PacketPeep.Widgets
                             offsetIdx++;
                         }
 
-                        scrollTo = offsetIdx * 17;
+                        scrollTo = offsetIdx * 22;
                     }
                 }
 

--- a/PacketPeep/Widgets/PacketExplorer.cs
+++ b/PacketPeep/Widgets/PacketExplorer.cs
@@ -175,9 +175,11 @@ namespace PacketPeep.Widgets
 
                 ImGui.SameLine();
                 if (ImGui.Button("Open") || ImGui.IsKeyPressedMap(ImGuiKey.Enter)) {
-                    ImGui.CloseCurrentPopup();
-                    ToggleMessageSelect(messageFinderMsgIdx);
-                    OnMessageSelected?.Invoke(messageFinderMsgIdx, false);
+                    if (pcktDb.FilteredIndices.Contains(messageFinderMsgIdx)) {
+                        ImGui.CloseCurrentPopup();
+                        ToggleMessageSelect(messageFinderMsgIdx);
+                        OnMessageSelected?.Invoke(messageFinderMsgIdx, false);
+                    }
                 }
 
                 if (ImGui.IsItemHovered()) ImGui.SetTooltip("Open the message in an inspector. [Enter]");


### PR DESCRIPTION
These changes fix two open issues related to the message finder.

Previously, if one tried to use the go to message on a message id that wasn't in the list, Peep would crash. Now, it does nothing instead, the popup will close as usual.

Previously, the go to line would not scroll to the correct line. I adjusted the magic offset value to one that works correctly, but I am not sure if this is dynamic or not.
